### PR TITLE
Add linux aarch64 wheel build support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,21 @@ matrix:
     env:
       - DOCKER_IMAGE=quay.io/pypa/manylinux1_i686
       - PRE_CMD=linux32
+  - sudo: required
+    dist: focal
+    arch: arm64
+    services:
+    - docker
+    env:
+      - DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
 before_install:
   - sudo apt-get update
   - sudo apt-get install -y cppcheck
   - pip install -r .ci/requirements.txt
   - pip install --upgrade --force-reinstall --ignore-installed --no-cache-dir git+git://github.com/deepdrive/problem-constants#egg=problem-constants
+  - if [ "${TRAVIS_CPU_ARCH}" == "arm64" ]; then
+    pip install --upgrade pip;
+    fi
   - pip install --upgrade --force-reinstall --ignore-installed --no-cache-dir git+git://github.com/botleague/botleague-helpers#egg=botleague-helpers
 install:
 - docker pull $DOCKER_IMAGE

--- a/Plugins/DeepDrivePlugin/Source/DeepDrivePython/build/build-linux-wheels.sh
+++ b/Plugins/DeepDrivePlugin/Source/DeepDrivePython/build/build-linux-wheels.sh
@@ -12,7 +12,7 @@ export DEEPDRIVE_SRC_DIR="$( dirname "$( dirname ${DIR})" )"
 echo DEEPDRIVE_SRC_DIR=${DEEPDRIVE_SRC_DIR}
 
 # Get python versions on docker image, i.e. /opt/python/cp35-cp35m/bin /opt/python/cp36-cp36m/bin ...
-py_versions_str=`cd ${DIR} && /opt/python/cp35-cp35m/bin/python -c "import build; print(build.get_centos_py_versions())"`
+py_versions_str=`cd ${DIR} && /opt/python/cp36-cp36m/bin/python -c "import build; print(build.get_centos_py_versions())"`
 py_versions=( ${py_versions_str} )
 
 # Delete previous builds (for testing locally)


### PR DESCRIPTION
Add linux aarch64 wheel build support. 

Related to https://github.com/deepdrive/deepdrive-sim/issues/41 @crizCraig Could you please review this PR?